### PR TITLE
Moving options to data-* attributes to fix #5, #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This bundle implements the [Bootstrap DateTime Picker](https://github.com/smalot/bootstrap-datetimepicker) in a Form Type for Symfony 2.*. The bundle structure is inspired by GenemuFormBundle.
 
-Demo : http://www.malot.fr/bootstrap-datetimepicker/demo.php
+Demo: http://www.malot.fr/bootstrap-datetimepicker/demo.php
 
 Please feel free to contribute, to fork, to send merge request and to create ticket.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for a translation other than German ("de") or remove if your are fine with Engli
 ``` twig
 	{% javascripts
 	    "@SCDatetimepickerBundle/Resources/public/js/bootstrap-datetimepicker.js"
-	    "@SCDatetimepickerBundle/Resources/public/js//locales/bootstrap-datetimepicker.de.js"
+	    "@SCDatetimepickerBundle/Resources/public/js/locales/bootstrap-datetimepicker.de.js"
 	%}
 	<script src="{{ asset_url }}"></script>
 	{% endjavascripts %}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ public function buildForm(FormBuilder $builder, array $options)
 
 Create a new JavaScript file (or add to one of your existing ones):
 
-''' js
+``` javascript
 $(document).ready(function() {
 	$('*[data-autostart-datetimepicker]').datetimepicker();
 });
@@ -117,7 +117,7 @@ HTML and JS is not a good idea from an architectural point.
 
 ## DateTimePicker Documentation
 
-The documentation of the datetime picker is here : http://www.malot.fr/bootstrap-datetimepicker/#options
+The documentation of the datetime picker is here: http://www.malot.fr/bootstrap-datetimepicker/#options
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,10 @@ Please feel free to contribute, to fork, to send merge request and to create tic
 
 ### Step 1: Install DatetimepickerBundle
 
-Add the following dependency to your composer.json file:
-
-``` json
-{
-    "require": {
-
-        "stephanecollot/datetimepicker-bundle": "dev-master"
-    }
-}
-```
-
-and then run
+Add the bundle to your composer.json file:
 
 ```bash
-php composer.phar update stephanecollot/datetimepicker-bundle
+php composer.phar require stephanecollot/datetimepicker-bundle
 ```
 
 ### Step 2: Enable the bundle
@@ -51,7 +40,29 @@ sc_datetimepicker:
 ### Step 3: Initialize assets
 
 ``` bash
-$ php app/console assets:install web/
+php app/console assets:install
+```
+
+###Step 4: Add CSS an JS to your main template
+
+Probably somewhere inside <head>..</head>
+``` twig
+	{% stylesheets
+	    "@SCDatetimepickerBundle/Resources/public/css/datetimepicker.css"
+	%}
+	<link type="text/css" rel="stylesheet" media="screen" href="{{ asset_url }}" />
+	{% endstylesheets %}
+```
+
+Probably shortly before ..</body>. Change the line referencing the second .js file
+for a translation other than German ("de") or remove if your are fine with English.
+``` twig
+	{% javascripts
+	    "@SCDatetimepickerBundle/Resources/public/js/bootstrap-datetimepicker.js"
+	    "@SCDatetimepickerBundle/Resources/public/js//locales/bootstrap-datetimepicker.de.js"
+	%}
+	<script src="{{ asset_url }}"></script>
+	{% endjavascripts %}
 ```
 
 ## Usages
@@ -92,37 +103,19 @@ public function buildForm(FormBuilder $builder, array $options)
 }
 ```
 
-Add form_javascript and form_stylesheet
+Create a new JavaScript file (or add to one of your existing ones):
 
-The principle is to separate the javascript, stylesheet and html.
-This allows better integration of web pages.
-
-### Example:
-
-``` twig
-{% block stylesheets %}
-    <link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet" />
-    
-    {{ form_stylesheet(form) }}
-{% endblock %}
-
-{% block javascripts %}
-    <script src="{{ asset('js/jquery.min.js') }}"></script>
-    <script src="{{ asset('js/bootstrap.min.js') }}"></script>
-    
-    {{ form_javascript(form) }}
-{% endblock %}
-
-{% block body %}
-    <form action="{{ path('my_route_form') }}" type="post" {{ form_enctype(form) }}>
-        {{ form_widget(form) }}
-
-        <input type="submit" />
-    </form>
-{% endblock %}
+''' js
+$(document).ready(function() {
+	$('*[data-autostart-datetimepicker]').datetimepicker();
+});
 ```
 
-## Documentation
+Adding that fragment directly in your view templates would also work, but mixing 
+HTML and JS is not a good idea from an architectural point.
+
+
+## DateTimePicker Documentation
 
 The documentation of the datetime picker is here : http://www.malot.fr/bootstrap-datetimepicker/#options
 

--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -1,8 +1,28 @@
 
-
 {% block collot_datetime_widget %}
 {% spaceless %}
+
+	{# Could not find a rule on how "data-" attributs map to datetimepicker options, so we need a full map #}
+	{% set optionsMap = {
+		format:				'date-format',
+		minView:			'min-view',
+		maxView:			'max-view',
+		formatter:			'formatter',
+		weekStart:			'date-weekstart',
+		autoclose:			'date-autoclose',
+		startView:			'start-view',
+		todayHighlight:		'date-today-highlight',
+		keyboardNavigation:	'date-keyboard-navigation',
+		forceParse:			'date-force-parse',
+		pickerPosition:		'picker-position',
+	} %}
+	
     {% if widget == "single_text" %}
+		{% for key in pickerOptions|keys %}
+            {% set attr = {('data-'~(optionsMap[key] ? optionsMap[key] : key)): pickerOptions[key]}|merge(attr) %}
+		{% endfor %}
+        {% set attr = {'data-autostart-datetimepicker': true}|merge(attr) %}
+    
         {{ block("form_widget_simple") }}
     {% else %}
         <div {{ block("widget_container_attributes") }}>

--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -15,6 +15,7 @@
 		keyboardNavigation:	'date-keyboard-navigation',
 		forceParse:			'date-force-parse',
 		pickerPosition:		'picker-position',
+		language:			'date-language',
 	} %}
 	
     {% if widget == "single_text" %}


### PR DESCRIPTION
Changed div_layout.html.twig to contain all options as data-* attributes
in the single_text form field. This allows initialization of
datetimepicker without option in JS and you can have several fields in
one form. Both form_javascript(form) and form_stylesheet(form) are not
needed any more (see README for details)

Fixes issues #5 and #20 