### PR TITLE
Do not use deprecated TwigRendererInterface

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -11,8 +11,8 @@
 
 namespace SC\DatetimepickerBundle\Twig\Extension;
 
+use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Bridge\Twig\Form\TwigRendererInterface;
 
 /**
  * FormExtension extends Twig with form capabilities.
@@ -29,7 +29,7 @@ class FormExtension extends \Twig_Extension
      */
     public $renderer;
 
-    public function __construct(TwigRendererInterface $renderer)
+    public function __construct(FormRendererInterface $renderer)
     {
         $this->renderer = $renderer;
     }


### PR DESCRIPTION
DatetimepickerBundle is incompatible with Symfony 3.4 and throws this error:

> Type error: Argument 1 passed to `SC\DatetimepickerBundle\Twig\Extension\FormExtension::__construct()` must be an instance of `Symfony\Bridge\Twig\Form\TwigRendererInterface`, instance of `Symfony\Component\Form\FormRenderer` given, called in `appDevDebugProjectContainer.php` on line 2005

`Symfony\Bridge\Twig\Form\TwigRendererInterface` was [deprecated in Symfony 3.2](https://github.com/symfony/symfony/blob/3.2/UPGRADE-3.2.md#twigbridge), and [as of Symfony 3.4](https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.4.md#twigbridge), `twig.form.renderer` is now an instance of `Symfony\Component\Form\FormRenderer` that does not implement `TwigRendererInterface`.

Simply adjusting the type hint fixes this issue. `TwigRendererInterface` inherits from `FormRenderer`, so this PR will work with both 3.4 and older versions.