### PR TITLE
changed type hint for deprecated service

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -12,7 +12,7 @@
 namespace SC\DatetimepickerBundle\Twig\Extension;
 
 use Symfony\Component\Form\FormView;
-use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\Form\FormRendererInterface;
 
 /**
  * FormExtension extends Twig with form capabilities.
@@ -29,7 +29,7 @@ class FormExtension extends \Twig_Extension
      */
     public $renderer;
 
-    public function __construct(TwigRendererInterface $renderer)
+    public function __construct(FormRendererInterface $renderer)
     {
         $this->renderer = $renderer;
     }


### PR DESCRIPTION
this fixes a reference to a deprecated service, which prevented the use of the bundle in symfony >=3.4